### PR TITLE
Updated extension for latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Disqus 0.8.7
+# Disqus 0.8.8
 
 Show Disqus comments on blog.
 

--- a/disqus.php
+++ b/disqus.php
@@ -2,7 +2,7 @@
 // Disqus extension, https://github.com/GiovanniSalmeri/yellow-disqus
 
 class YellowDisqus {
-    const VERSION = "0.8.7";
+    const VERSION = "0.8.8";
     public $yellow;         // access to API
     
     // Handle initialisation
@@ -16,7 +16,11 @@ class YellowDisqus {
         $output = null;
         if ($name=="disqus" && ($type=="block" || $type=="inline") && !preg_match("/exclude/i", $page->get("comment"))) {
             $shortname = $this->yellow->system->get("disqusShortname");
-            $url = $page->get("pageReadUrl");
+            $url = $this->yellow->lookup->normaliseUrl(
+                $this->yellow->system->get("coreServerScheme"),
+                $this->yellow->system->get("coreServerAddress"),
+                $this->yellow->system->get("coreServerBase"),
+                $page->location);
             $language = $page->get("language");
             $output = "<div id=\"disqus_thread\" data-shortname=\"".htmlspecialchars($shortname)."\" data-url=\"".htmlspecialchars($url)."\" data-language=\"$language\"></div>\n";
         }

--- a/extension.ini
+++ b/extension.ini
@@ -1,11 +1,11 @@
 # Datenstrom Yellow extension settings
 
 Extension: Disqus
-Version: 0.8.7
+Version: 0.8.8
 Description: Show Disqus comments on blog.
 DocumentationUrl: https://github.com/GiovanniSalmeri/yellow-disqus
 DownloadUrl: https://github.com/GiovanniSalmeri/yellow-disqus/archive/main.zip
-Published: 2021-06-10 21:46:14
+Published: 2022-11-05 11:59:42
 Developer: Giovanni Salmeri
 Tag: feature
 system/extensions/disqus.php: disqus.php, create, update


### PR DESCRIPTION
In latest core the setting `pageReadUrl` was removed. Here's an alternative I like to suggest. Hope it helps.